### PR TITLE
Ensure consistent definitions of SIXTY_FOUR_BIT_LONG

### DIFF
--- a/crypto/openssl/include/crypto/bn_conf.h
+++ b/crypto/openssl/include/crypto/bn_conf.h
@@ -22,14 +22,16 @@
 /* Should we define BN_DIV2W here? */
 
 /* Only one for the following should be defined */
-#ifdef __LP64__
-#define SIXTY_FOUR_BIT_LONG
-#undef SIXTY_FOUR_BIT
-#undef THIRTY_TWO_BIT
-#else
-#undef SIXTY_FOUR_BIT_LONG
-#undef SIXTY_FOUR_BIT
-#define THIRTY_TWO_BIT
-#endif
+# if __SIZEOF_LONG__ == 8
+#  define SIXTY_FOUR_BIT_LONG
+#  undef SIXTY_FOUR_BIT
+#  undef THIRTY_TWO_BIT
+# elif __SIZEOF_LONG__ == 4
+#  undef SIXTY_FOUR_BIT_LONG
+#  undef SIXTY_FOUR_BIT
+#  define THIRTY_TWO_BIT
+# else
+#  error Unsupported size of long
+# endif
 
 #endif

--- a/crypto/openssl/include/openssl/configuration.h
+++ b/crypto/openssl/include/openssl/configuration.h
@@ -123,11 +123,21 @@ extern "C" {
  * The following are cipher-specific, but are part of the public API.
  */
 # if !defined(OPENSSL_SYS_UEFI)
-#  undef BN_LLONG
+#  if __SIZEOF_LONG__ == 8
+#   undef BN_LLONG
 /* Only one for the following should be defined */
-#  define SIXTY_FOUR_BIT_LONG
-#  undef SIXTY_FOUR_BIT
-#  undef THIRTY_TWO_BIT
+#   define SIXTY_FOUR_BIT_LONG
+#   undef SIXTY_FOUR_BIT
+#   undef THIRTY_TWO_BIT
+#  elif __SIZEOF_LONG__ == 4
+#   define BN_LLONG
+/* Only one for the following should be defined */
+#   undef SIXTY_FOUR_BIT_LONG
+#   undef SIXTY_FOUR_BIT
+#   define THIRTY_TWO_BIT
+#  else
+#   error Unsupported size of long
+#  endif
 # endif
 
 # define RC4_INT unsigned int


### PR DESCRIPTION
Ensure consistent definitions of SIXTY_FOUR_BIT_LONG (for __LP64__ platforms) or THIRTY_TWO_BIT (for non-__LP64__). Otherwise, for example on i386, the openssl bignum routines will attempt to use 32-bit shifts on 32-bit unsigned longs, which is undefined behavior.

This is the cause for the segfaults on i386, mentioned in https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=271656#c23
